### PR TITLE
fix: 和 cube-reconstruction 保持一致，调用时先以环境注册优先

### DIFF
--- a/runtime/cube.js
+++ b/runtime/cube.js
@@ -216,7 +216,7 @@
    * @returns {*}
    */
   function fireModule(module) {
-    var m = installedModules[module] || getGlobalRegister(module);
+    var m = getGlobalRegister(module) || installedModules[module];
     if (!m) {
       const err = new Error('Cube Error: Cannot find module ' + '\'' + module + '\'');
       if (strict) {


### PR DESCRIPTION
fix: 和 cube-reconstruction 保持一致，调用时先以环境注册优先